### PR TITLE
runbot: switch to -e

### DIFF
--- a/runbot
+++ b/runbot
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -a /usr/bin/lua ]
+if [ -e /usr/bin/lua ]
 	then
 		while :
 			do


### PR DESCRIPTION
The flag -a is deprecated, and -e has the exact same function